### PR TITLE
Make action more modular, improve security and docs

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -16,7 +16,7 @@ jobs:
       - id: state-download
         uses: devgioele/terraform-state-artifact@v3
         with:
-          passphrase: ${{ secrets.TF-STATE-PASSPHRASE }}
+          passphrase: ${{ secrets.TF_STATE_PASSPHRASE }}
           download-upload: download
   terraform-upload-job:
     runs-on: ubuntu-latest
@@ -25,5 +25,5 @@ jobs:
       - id: state-upload
         uses: devgioele/terraform-state-artifact@v3
         with:
-          passphrase: ${{ secrets.TF-STATE-PASSPHRASE }}
+          passphrase: ${{ secrets.TF_STATE_PASSPHRASE }}
           download-upload: upload

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -9,20 +9,26 @@ on:
     - cron:  '11 11 11 * *'
 
 jobs:
-  terraform-download-job:
+  download-apply-upload:
     runs-on: ubuntu-latest
-    name: Downloading Terraform state
     steps:
-      - id: state-download
+      - uses: actions/checkout@v3
+      - name: Download Terraform state
         uses: devgioele/terraform-state-artifact@v3
         with:
           passphrase: ${{ secrets.TF_STATE_PASSPHRASE }}
           download-upload: download
-  terraform-upload-job:
-    runs-on: ubuntu-latest
-    name: Uploading Terraform state
-    steps:
-      - id: state-upload
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_wrapper: false
+      - name: Terraform init
+        run: terraform init
+      - name: Terraform validate
+        run: terraform validate
+      - name: Terraform apply
+        run: terraform apply -auto-approve
+      - id: Upload Terraform state
         uses: devgioele/terraform-state-artifact@v3
         with:
           passphrase: ${{ secrets.TF_STATE_PASSPHRASE }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,4 +1,4 @@
-name: Terraform State Artifact
+name: Integration test
 
 on:
   push:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Download Terraform state
-        uses: devgioele/terraform-state-artifact@v3
+        uses: devgioele/terraform-state-artifact@v4
         with:
           passphrase: ${{ secrets.TF_STATE_PASSPHRASE }}
           download_upload: download
@@ -29,7 +29,7 @@ jobs:
       - name: Terraform apply
         run: terraform apply -auto-approve -var="run_id=${{ github.run_id }}"
       - name: Upload Terraform state
-        uses: devgioele/terraform-state-artifact@v3
+        uses: devgioele/terraform-state-artifact@v4
         with:
           passphrase: ${{ secrets.TF_STATE_PASSPHRASE }}
           download_upload: upload

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Terraform validate
         run: terraform validate
       - name: Terraform apply
-        run: terraform apply -auto-approve
+        run: terraform apply -auto-approve -var="run_id=${{ github.run_id }}"
       - name: Upload Terraform state
         uses: devgioele/terraform-state-artifact@v3
         with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -28,7 +28,7 @@ jobs:
         run: terraform validate
       - name: Terraform apply
         run: terraform apply -auto-approve
-      - id: Upload Terraform state
+      - name: Upload Terraform state
         uses: devgioele/terraform-state-artifact@v3
         with:
           passphrase: ${{ secrets.TF_STATE_PASSPHRASE }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -17,7 +17,7 @@ jobs:
         uses: devgioele/terraform-state-artifact@v3
         with:
           passphrase: ${{ secrets.TF_STATE_PASSPHRASE }}
-          download-upload: download
+          download_upload: download
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v2
         with:
@@ -32,4 +32,4 @@ jobs:
         uses: devgioele/terraform-state-artifact@v3
         with:
           passphrase: ${{ secrets.TF_STATE_PASSPHRASE }}
-          download-upload: upload
+          download_upload: upload

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -25,5 +25,5 @@ jobs:
       - id: state-upload
         uses: devgioele/terraform-state-artifact@v3
         with:
-          encryption-key: ${{ secrets.pat }}
+          passphrase: ${{ secrets.TF-STATE-PASSPHRASE }}
           download-upload: upload

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,6 +1,7 @@
 name: Integration test
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,28 +1,29 @@
 name: Terraform State Artifact
+
 on:
   push:
     branches:
       - main
   schedule:
+    # Every month
     - cron:  '11 11 11 * *'
 
-
 jobs:
-  terraform_download_job:
+  terraform-download-job:
     runs-on: ubuntu-latest
-    name: Downloading terraform_state_artifact
+    name: Downloading Terraform state
     steps:
-      - id: terrafrom_artifact_download
-        uses: sturlabragason/terraform_state_artifact@v2
+      - id: state-download
+        uses: devgioele/terraform-state-artifact@v3
         with:
-          encryptionkey: ${{ secrets.pat }}
-          download_upload: download
-  terraform_upload_job:
+          encryption-key: ${{ secrets.pat }}
+          download-upload: download
+  terraform-upload-job:
     runs-on: ubuntu-latest
-    name: Uploading terraform_state_artifact
+    name: Uploading Terraform state
     steps:
-      - id: terrafrom_artifact_upload
-        uses: sturlabragason/terraform_state_artifact@v2
+      - id: state-upload
+        uses: devgioele/terraform-state-artifact@v3
         with:
-          encryptionkey: ${{ secrets.pat }}
-          download_upload: upload
+          encryption-key: ${{ secrets.pat }}
+          download-upload: upload

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -16,7 +16,7 @@ jobs:
       - id: state-download
         uses: devgioele/terraform-state-artifact@v3
         with:
-          encryption-key: ${{ secrets.pat }}
+          passphrase: ${{ secrets.TF-STATE-PASSPHRASE }}
           download-upload: download
   terraform-upload-job:
     runs-on: ubuntu-latest

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -8,47 +8,21 @@ on:
 
 
 jobs:
-  terraform_default_job:
+  terraform_download_job:
     runs-on: ubuntu-latest
-    name: Using terraform_state_artifact action
+    name: Downloading terraform_state_artifact
     steps:
-      - id: terrafrom_state_artifact
-        uses: sturlabragason/terraform_state_artifact@v1
+      - id: terrafrom_artifact_download
+        uses: sturlabragason/terraform_state_artifact@v2
         with:
           encryptionkey: ${{ secrets.pat }}
-        env:
-          TF_VAR_run_id: ${{ github.run_id }}
-  terraform_apply_false_job:
+          download_upload: download
+  terraform_upload_job:
     runs-on: ubuntu-latest
-    name: Using terraform_state_artifact action without apply
+    name: Uploading terraform_state_artifact
     steps:
-      - id: terraform_apply_false
-        uses: sturlabragason/terraform_state_artifact@v1
+      - id: terrafrom_artifact_upload
+        uses: sturlabragason/terraform_state_artifact@v2
         with:
           encryptionkey: ${{ secrets.pat }}
-          apply: false
-        env:
-          TF_VAR_run_id: ${{ github.run_id }}
-  terraform_plan_custom_job:
-    runs-on: ubuntu-latest
-    name: Using terraform_state_artifact with custom plan flag
-    steps:
-      - id: terraform_plan_custom
-        uses: sturlabragason/terraform_state_artifact@v1
-        with:
-          encryptionkey: ${{ secrets.pat }}
-          apply: false
-          custom_plan_flags: '-refresh-only'
-        env:
-          TF_VAR_run_id: ${{ github.run_id }}
-  terraform_apply_custom_job:
-    runs-on: ubuntu-latest
-    name: Using terraform_state_artifact with custom apply flag
-    steps:
-      - id: terraform_apply_custom
-        uses: sturlabragason/terraform_state_artifact@v1
-        with:
-          encryptionkey: ${{ secrets.pat }}
-          custom_apply_flags: '-no-color'
-        env:
-          TF_VAR_run_id: ${{ github.run_id }}
+          download_upload: upload

--- a/README.md
+++ b/README.md
@@ -7,6 +7,14 @@ An action that stores your Terraform state file as an encrypted Github workflow 
 
 Be aware that [Github delets artifacts older then 90 days](https://docs.github.com/en/organizations/managing-organization-settings/configuring-the-retention-period-for-github-actions-artifacts-and-logs-in-your-organization) by default. You can [run your pipeline on a schedule](https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#scheduled-events) to create a new artifact at least once every 90 days.
 
+## ⚠️ WARNING ⚠️
+
+There is currently a security vulnerability that might stop you from using this action for any serious application.
+
+As the StackExchange post ["Encrypting using AES 256, do I need IV?"](https://security.stackexchange.com/questions/35210/encrypting-using-aes-256-do-i-need-iv) explains, using each time the same key for encrypting the artifact without using a IV, is unsecure.
+
+A fix is being searched and you are welcome to open a PR.
+
 ## Usage
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -10,9 +10,27 @@ Be aware that [Github delets artifacts older then 90 days](https://docs.github.c
 
 ```yaml
 steps:
-- uses: devgioele/terraform-state-artifact@v3
-    with:
+  - uses: actions/checkout@v3
+    - name: Download Terraform state
+      uses: devgioele/terraform-state-artifact@v4
+      with:
         passphrase: ${{ secrets.TF_STATE_PASSPHRASE }}
+        download_upload: download
+    - name: Setup Terraform
+      uses: hashicorp/setup-terraform@v2
+      with:
+        terraform_wrapper: false
+    - name: Terraform init
+      run: terraform init
+    - name: Terraform validate
+      run: terraform validate
+    - name: Terraform apply
+      run: terraform apply -auto-approve -var="run_id=${{ github.run_id }}"
+    - name: Upload Terraform state
+      uses: devgioele/terraform-state-artifact@v4
+      with:
+        passphrase: ${{ secrets.TF_STATE_PASSPHRASE }}
+        download_upload: upload
 ```
 
 Generate a secure password and store in a GitHub secret named `TF_STATE_PASSPHRASE`.
@@ -24,8 +42,8 @@ The action supports the following inputs:
 | Variable        | Description                                                                                                                             | Default |
 |-----------------|-----------------------------------------------------------------------------------------------------------------------------------------|---------|
 | `passphrase` | A passphrase to encrypt and decrypt the statefile artifact.                       | N/A |
-| `download-upload`         | Whether to download and decrypt or upload and encrypt.               | N/A |
-| `statefile-location`         | (optional) The location of your Terraform statefile.              | `''` |
+| `download_upload`         | Whether to download and decrypt or upload and encrypt.               | N/A |
+| `statefile_location`         | (optional) The location of your Terraform statefile.              | `''` |
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -11,26 +11,26 @@ Be aware that [Github delets artifacts older then 90 days](https://docs.github.c
 ```yaml
 steps:
   - uses: actions/checkout@v3
-    - name: Download Terraform state
-      uses: devgioele/terraform-state-artifact@v4
-      with:
-        passphrase: ${{ secrets.TF_STATE_PASSPHRASE }}
-        download_upload: download
-    - name: Setup Terraform
-      uses: hashicorp/setup-terraform@v2
-      with:
-        terraform_wrapper: false
-    - name: Terraform init
-      run: terraform init
-    - name: Terraform validate
-      run: terraform validate
-    - name: Terraform apply
-      run: terraform apply -auto-approve -var="run_id=${{ github.run_id }}"
-    - name: Upload Terraform state
-      uses: devgioele/terraform-state-artifact@v4
-      with:
-        passphrase: ${{ secrets.TF_STATE_PASSPHRASE }}
-        download_upload: upload
+  - name: Download Terraform state
+    uses: devgioele/terraform-state-artifact@v4
+    with:
+      passphrase: ${{ secrets.TF_STATE_PASSPHRASE }}
+      download_upload: download
+  - name: Setup Terraform
+    uses: hashicorp/setup-terraform@v2
+    with:
+      terraform_wrapper: false
+  - name: Terraform init
+    run: terraform init
+  - name: Terraform validate
+    run: terraform validate
+  - name: Terraform apply
+    run: terraform apply -auto-approve -var="run_id=${{ github.run_id }}"
+  - name: Upload Terraform state
+    uses: devgioele/terraform-state-artifact@v4
+    with:
+      passphrase: ${{ secrets.TF_STATE_PASSPHRASE }}
+      download_upload: upload
 ```
 
 Generate a secure password and store in a GitHub secret named `TF_STATE_PASSPHRASE`.

--- a/README.md
+++ b/README.md
@@ -1,64 +1,27 @@
-# terraform_state_artifact 
-[![Terraform State Artifact](https://github.com/sturlabragason/terraform_state_artifact/actions/workflows/terraform.yml/badge.svg)](https://github.com/sturlabragason/terraform_state_artifact/actions/workflows/terraform.yml)
+# terraform-state-artifact
+
+[![Terraform State Artifact](https://github.com/devgioele/terraform-state-artifact/actions/workflows/terraform.yml/badge.svg)](https://github.com/devgioele/terraform-state-artifact/actions/workflows/terraform.yml)
   `#actionshackathon21`
 
-The [`sturlabragason/terraform_state_artifact`](https://github.com/sturlabragason/terraform_state_artifact) action is a composite action that stores your Terraform state file as an encrypted Github workflow artifact and downloads and decrypts the state on subsequent runs. Built-in are the actions: [`actions/checkout@v2`](https://github.com/actions/checkout), [`hashicorp/setup-terraform@v2`](https://github.com/hashicorp/setup-terraform) and [`actions/upload-artifact@v2`](https://github.com/actions/upload-artifact).
+An action that stores your Terraform state file as an encrypted Github workflow artifact and downloads and decrypts the state on subsequent runs.
 
 Be aware that [Github delets artifacts older then 90 days](https://docs.github.com/en/organizations/managing-organization-settings/configuring-the-retention-period-for-github-actions-artifacts-and-logs-in-your-organization) by default. You can [run your pipeline on a schedule](https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#scheduled-events) to create a new artifact at least once every 90 days.
-
-## [:rocket: What this action does: :rocket:](https://dev.to/sturlabragason/terraformstateartifact-github-action-keeping-the-statefile-with-to-your-code-4d3b)
-
-- 🛠️ First off, it downloads your repository with [`actions/checkout@v2`](https://github.com/actions/checkout) and then installs terraform using [`hashicorp/setup-terraform@v2`](https://github.com/hashicorp/setup-terraform).
-- :inbox_tray: Using [environment variables](https://docs.github.com/en/actions/learn-github-actions/environment-variables) it downloads the most recent [workflow artifact](https://docs.github.com/en/actions/advanced-guides/storing-workflow-data-as-artifacts) called `terraformstatefile` and decrypts using the user input variable `encryptionkey`.
-  - If no artifact with that name is found (maybe it's your first run) then it proceeds with the following.
-- :building_construction: It then proceeds to run `terraform plan` with any flags from the optional variable `custom_plan_flags`
-- 🏢 Next it runs `terraform apply` with any flags from the optional variable`custom_apply_flags`.
-  - This can be skipped by setting the optional variable `apply` to `false`.
-- 🗃️ If all is well then Terraform has now produced a statefile `./terraform.tfstate`. This file is encrypted using the provided `encryptionkey`.
-    - 🤫 I'd recommend getting this from a [`${{secret.variable}}`](https://docs.github.com/en/actions/security-guides/encrypted-secrets) since the output isn't hidden.
-- 💾 Finally the new statefile is uploaded as an artifact!
-#### - :tada: Lather, rinse, repeat! :tada:
-
 
 ## Usage
 
 ```yaml
 steps:
-- uses: sturlabragason/terraform_state_artifact@v2
+- uses: devgioele/terraform-state-artifact@v3
     with:
-        encryptionkey: ${{ secrets.encryptionkey }}
+        encryption-key: ${{ secrets.TF-STATE-KEY }}
 ```
 
-You can choose to skip `terraform apply`:
-
-```yaml
-steps:
-- uses: sturlabragason/terraform_state_artifact@v2
-    with:
-        encryptionkey: ${{ secrets.encryptionkey }}
-        apply: false
+Using OpenSSL 1.1.1, a key can be generated with:
 ```
-
-You can choose to add custom flags to `terraform plan`:
-
-```yaml
-steps:
-- uses: sturlabragason/terraform_state_artifact@v2
-    with:
-        encryptionkey: ${{ secrets.encryptionkey }}
-        apply: false
-        custom_plan_flags: '-refresh-only'
+openssl enc -aes-256-cbc -k <secret> -P -md sha256 -pbkdf2
 ```
-
-You can choose to add custom flags to `terraform apply`:
-
-```yaml
-steps:
-- uses: sturlabragason/terraform_state_artifact@v2
-    with:
-        encryptionkey: ${{ secrets.encryptionkey }}
-        custom_apply_flags: '-no-color'
-```
+Replace `<secret>` with some password.
+Copy the key from the output and use it as a GitHub secret named `TF-STATE-KEY`.
 
 ## Inputs
 
@@ -66,9 +29,14 @@ The action supports the following inputs:
 
 | Variable        | Description                                                                                                                             | Default |
 |-----------------|-----------------------------------------------------------------------------------------------------------------------------------------|---------|
-| `encryptionkey` | An encryption key to use when encrypting the statefile. Recommended to use a secret value.                                              |   N/A   |
-| `statefile_location`         | (optional) Add a custom flag to the `terraform plan` command.               | `''`  |
+| `encryption-key` | An encryption key to use when encrypting the statefile. Recommended to use a secret value.                                              |   N/A   |
+| `download-upload`         | Whether to download and decrypt or upload and encrypt.               | N/A |
+| `statefile-location`         | (optional) The location of your Terraform statefile.               | `''`  |
+
+## Credits
+
+This action would not have been possible without [the previous work done by sturlabragason](https://github.com/sturlabragason/terraform_state_artifact). I created a fork instead of a PR, because I wanted my changes to take immediate effect.
 
 ## License
 
-[GNU General Public License v3.0](https://github.com/sturlabragason/terraform_state_artifact/blob/main/LICENSE)
+[GNU General Public License v3.0](https://github.com/devgioele/terraform-state-artifact/blob/main/LICENSE)

--- a/README.md
+++ b/README.md
@@ -6,14 +6,6 @@ An action that stores your Terraform state file as an encrypted Github workflow 
 
 Be aware that [Github delets artifacts older then 90 days](https://docs.github.com/en/organizations/managing-organization-settings/configuring-the-retention-period-for-github-actions-artifacts-and-logs-in-your-organization) by default. You can [run your pipeline on a schedule](https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#scheduled-events) to create a new artifact at least once every 90 days.
 
-## ⚠️ WARNING ⚠️
-
-There is currently a security vulnerability that might stop you from using this action for any serious application.
-
-As the StackExchange post ["Encrypting using AES 256, do I need IV?"](https://security.stackexchange.com/questions/35210/encrypting-using-aes-256-do-i-need-iv) explains, using each time the same key for encrypting the artifact without using a IV, is unsecure.
-
-A fix is being searched and you are welcome to open a PR.
-
 ## Usage
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A fix is being searched and you are welcome to open a PR.
 steps:
 - uses: devgioele/terraform-state-artifact@v3
     with:
-        passphrase: ${{ secrets.TF-STATE-PASSPHRASE }}
+        passphrase: ${{ secrets.TF_STATE_PASSPHRASE }}
 ```
 
 Using OpenSSL 1.1.1, a key can be generated with:
@@ -28,7 +28,7 @@ Using OpenSSL 1.1.1, a key can be generated with:
 openssl enc -aes-256-cbc -k <secret> -P -md sha256 -pbkdf2
 ```
 Replace `<secret>` with some password.
-Copy the key from the output and use it as a GitHub secret named `TF-STATE-PASSPHRASE`.
+Copy the key from the output and use it as a GitHub secret named `TF_STATE_PASSPHRASE`.
 
 ## Inputs
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A fix is being searched and you are welcome to open a PR.
 steps:
 - uses: devgioele/terraform-state-artifact@v3
     with:
-        encryption-key: ${{ secrets.TF-STATE-KEY }}
+        passphrase: ${{ secrets.TF-STATE-PASSPHRASE }}
 ```
 
 Using OpenSSL 1.1.1, a key can be generated with:
@@ -28,7 +28,7 @@ Using OpenSSL 1.1.1, a key can be generated with:
 openssl enc -aes-256-cbc -k <secret> -P -md sha256 -pbkdf2
 ```
 Replace `<secret>` with some password.
-Copy the key from the output and use it as a GitHub secret named `TF-STATE-KEY`.
+Copy the key from the output and use it as a GitHub secret named `TF-STATE-PASSPHRASE`.
 
 ## Inputs
 
@@ -36,9 +36,9 @@ The action supports the following inputs:
 
 | Variable        | Description                                                                                                                             | Default |
 |-----------------|-----------------------------------------------------------------------------------------------------------------------------------------|---------|
-| `encryption-key` | An encryption key to use when encrypting the statefile. Recommended to use a secret value.                                              |   N/A   |
+| `passphrase` | A passphrase to encrypt and decrypt the statefile artifact.                       | N/A |
 | `download-upload`         | Whether to download and decrypt or upload and encrypt.               | N/A |
-| `statefile-location`         | (optional) The location of your Terraform statefile.               | `''`  |
+| `statefile-location`         | (optional) The location of your Terraform statefile.              | `''` |
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # terraform-state-artifact
 
-[![Terraform State Artifact](https://github.com/devgioele/terraform-state-artifact/actions/workflows/terraform.yml/badge.svg)](https://github.com/devgioele/terraform-state-artifact/actions/workflows/terraform.yml)
+[![Terraform State Artifact](https://github.com/devgioele/terraform-state-artifact/actions/workflows/integration.yml/badge.svg)](https://github.com/devgioele/terraform-state-artifact/actions/workflows/integration.yml)
 
 An action that stores your Terraform state file as an encrypted Github workflow artifact and downloads and decrypts the state on subsequent runs.
 

--- a/README.md
+++ b/README.md
@@ -18,14 +18,12 @@ steps:
       download_upload: download
   - name: Setup Terraform
     uses: hashicorp/setup-terraform@v2
-    with:
-      terraform_wrapper: false
   - name: Terraform init
     run: terraform init
   - name: Terraform validate
     run: terraform validate
   - name: Terraform apply
-    run: terraform apply -auto-approve -var="run_id=${{ github.run_id }}"
+    run: terraform apply -auto-approve
   - name: Upload Terraform state
     uses: devgioele/terraform-state-artifact@v4
     with:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # terraform-state-artifact
 
 [![Terraform State Artifact](https://github.com/devgioele/terraform-state-artifact/actions/workflows/terraform.yml/badge.svg)](https://github.com/devgioele/terraform-state-artifact/actions/workflows/terraform.yml)
-  `#actionshackathon21`
 
 An action that stores your Terraform state file as an encrypted Github workflow artifact and downloads and decrypts the state on subsequent runs.
 

--- a/README.md
+++ b/README.md
@@ -15,12 +15,7 @@ steps:
         passphrase: ${{ secrets.TF_STATE_PASSPHRASE }}
 ```
 
-Using OpenSSL 1.1.1, a key can be generated with:
-```
-openssl enc -aes-256-cbc -k <secret> -P -md sha256 -pbkdf2
-```
-Replace `<secret>` with some password.
-Copy the key from the output and use it as a GitHub secret named `TF_STATE_PASSPHRASE`.
+Generate a secure password and store in a GitHub secret named `TF_STATE_PASSPHRASE`.
 
 ## Inputs
 

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 [![Terraform State Artifact](https://github.com/sturlabragason/terraform_state_artifact/actions/workflows/terraform.yml/badge.svg)](https://github.com/sturlabragason/terraform_state_artifact/actions/workflows/terraform.yml)
   `#actionshackathon21`
 
-The [`sturlabragason/terraform_state_artifact`](https://github.com/sturlabragason/terraform_state_artifact) action is a composite action that stores your Terraform state file as an encrypted Github workflow artifact and downloads and decrypts the state on subsequent runs. Built-in are the actions: [`actions/checkout@v2`](https://github.com/actions/checkout), [`hashicorp/setup-terraform@v1`](https://github.com/hashicorp/setup-terraform) and [`actions/upload-artifact@v2`](https://github.com/actions/upload-artifact).
+The [`sturlabragason/terraform_state_artifact`](https://github.com/sturlabragason/terraform_state_artifact) action is a composite action that stores your Terraform state file as an encrypted Github workflow artifact and downloads and decrypts the state on subsequent runs. Built-in are the actions: [`actions/checkout@v2`](https://github.com/actions/checkout), [`hashicorp/setup-terraform@v2`](https://github.com/hashicorp/setup-terraform) and [`actions/upload-artifact@v2`](https://github.com/actions/upload-artifact).
 
 Be aware that [Github delets artifacts older then 90 days](https://docs.github.com/en/organizations/managing-organization-settings/configuring-the-retention-period-for-github-actions-artifacts-and-logs-in-your-organization) by default. You can [run your pipeline on a schedule](https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#scheduled-events) to create a new artifact at least once every 90 days.
 
 ## [:rocket: What this action does: :rocket:](https://dev.to/sturlabragason/terraformstateartifact-github-action-keeping-the-statefile-with-to-your-code-4d3b)
 
-- 🛠️ First off, it downloads your repository with [`actions/checkout@v2`](https://github.com/actions/checkout) and then installs terraform using [`hashicorp/setup-terraform@v1`](https://github.com/hashicorp/setup-terraform).
+- 🛠️ First off, it downloads your repository with [`actions/checkout@v2`](https://github.com/actions/checkout) and then installs terraform using [`hashicorp/setup-terraform@v2`](https://github.com/hashicorp/setup-terraform).
 - :inbox_tray: Using [environment variables](https://docs.github.com/en/actions/learn-github-actions/environment-variables) it downloads the most recent [workflow artifact](https://docs.github.com/en/actions/advanced-guides/storing-workflow-data-as-artifacts) called `terraformstatefile` and decrypts using the user input variable `encryptionkey`.
   - If no artifact with that name is found (maybe it's your first run) then it proceeds with the following.
 - :building_construction: It then proceeds to run `terraform plan` with any flags from the optional variable `custom_plan_flags`
@@ -24,7 +24,7 @@ Be aware that [Github delets artifacts older then 90 days](https://docs.github.c
 
 ```yaml
 steps:
-- uses: sturlabragason/terraform_state_artifact@v1
+- uses: sturlabragason/terraform_state_artifact@v2
     with:
         encryptionkey: ${{ secrets.encryptionkey }}
 ```
@@ -33,7 +33,7 @@ You can choose to skip `terraform apply`:
 
 ```yaml
 steps:
-- uses: sturlabragason/terraform_state_artifact@v1
+- uses: sturlabragason/terraform_state_artifact@v2
     with:
         encryptionkey: ${{ secrets.encryptionkey }}
         apply: false
@@ -43,7 +43,7 @@ You can choose to add custom flags to `terraform plan`:
 
 ```yaml
 steps:
-- uses: sturlabragason/terraform_state_artifact@v1
+- uses: sturlabragason/terraform_state_artifact@v2
     with:
         encryptionkey: ${{ secrets.encryptionkey }}
         apply: false
@@ -54,7 +54,7 @@ You can choose to add custom flags to `terraform apply`:
 
 ```yaml
 steps:
-- uses: sturlabragason/terraform_state_artifact@v1
+- uses: sturlabragason/terraform_state_artifact@v2
     with:
         encryptionkey: ${{ secrets.encryptionkey }}
         custom_apply_flags: '-no-color'
@@ -67,9 +67,7 @@ The action supports the following inputs:
 | Variable        | Description                                                                                                                             | Default |
 |-----------------|-----------------------------------------------------------------------------------------------------------------------------------------|---------|
 | `encryptionkey` | An encryption key to use when encrypting the statefile. Recommended to use a secret value.                                              |   N/A   |
-| `apply`         | (optional) Whether to run the `terraform apply` command.               | `true`  |
-| `custom_plan_flags`         | (optional) Add a custom flag to the `terraform plan` command.               | `''`  |
-| `custom_apply_flags`         | (optional) Add a custom flag to the `terraform apply` command.               | `''`  |
+| `statefile_location`         | (optional) Add a custom flag to the `terraform plan` command.               | `''`  |
 
 ## License
 

--- a/action.yml
+++ b/action.yml
@@ -20,11 +20,11 @@ runs:
     - id: terraform-state-artifact-download
       if: ${{ inputs.download_upload == 'download' }}
       run: |
-        $ArtifactName = ${{ github.ref_name }} + ${{ inputs.statefile_location }}
-        $Repo = ${{ github.repository }}
+        $ArtifactName = "${{ github.ref_name }}" + "${{ inputs.statefile_location }}"
+        $Repo = "${{ github.repository }}"
         $BaseUri = "https://api.github.com"
         $ArtifactUri = "$BaseUri/repos/$Repo/actions/artifacts"
-        $Token = ${{ github.token }} | ConvertTo-SecureString -AsPlainText
+        $Token = "${{ github.token }}" | ConvertTo-SecureString -AsPlainText
         $RestResponse = Invoke-RestMethod -Authentication Bearer -Uri $ArtifactUri -Token $Token | Select-Object -ExpandProperty artifacts
         if ($RestResponse){
           $MostRecentArtifactURI = $RestResponse | Sort-Object -Property created_at -Descending | where name -eq $ArtifactName | Select-Object -First 1 | Select-Object -ExpandProperty archive_download_url
@@ -39,7 +39,7 @@ runs:
     - id: terraform-state-artifact-upload
       if: ${{ inputs.download_upload == 'upload' }}
       run: |
-        $ArtifactName = ${{ github.ref_name }} + ${{ inputs.statefile_location }}
+        $ArtifactName = "${{ github.ref_name }}" + "${{ inputs.statefile_location }}"
         $StateExists = Test-Path -Path .${{ inputs.statefile_location }}/terraform.tfstate -PathType Leaf
         if ($StateExists){
           gpg --batch --symmetric --cipher-algo aes256 --digest-algo sha256 --passphrase ${{ inputs.passphrase }} -o .${{ inputs.statefile_location }}/terraform.tfstate.enc .${{ inputs.statefile_location }}/terraform.tfstate

--- a/action.yml
+++ b/action.yml
@@ -20,11 +20,11 @@ runs:
     - id: terraform-state-artifact-download
       if: ${{ inputs.download_upload == 'download' }}
       run: |
-        $ArtifactName = "${{ github.ref_name }}" + "${{ inputs.statefile_location }}"
-        $Repo = "${{ github.repository }}"
+        $ArtifactName = ${{ github.ref_name }} + ${{ inputs.statefile_location }}
+        $Repo = ${{ github.repository }}
         $BaseUri = "https://api.github.com"
         $ArtifactUri = "$BaseUri/repos/$Repo/actions/artifacts"
-        $Token = "${{ github.token }}" | ConvertTo-SecureString -AsPlainText
+        $Token = ${{ github.token }} | ConvertTo-SecureString -AsPlainText
         $RestResponse = Invoke-RestMethod -Authentication Bearer -Uri $ArtifactUri -Token $Token | Select-Object -ExpandProperty artifacts
         if ($RestResponse){
           $MostRecentArtifactURI = $RestResponse | Sort-Object -Property created_at -Descending | where name -eq $ArtifactName | Select-Object -First 1 | Select-Object -ExpandProperty archive_download_url
@@ -32,24 +32,24 @@ runs:
           if ($MostRecentArtifactURI){
             Invoke-RestMethod -uri $MostRecentArtifactURI -Token $Token -Authentication bearer -outfile ./state.zip
             Expand-Archive ./state.zip
-            gpg --batch --passphrase "${{ inputs.passphrase }}" -o ."${{ inputs.statefile_location }}"/terraform.tfstate -d ./state/terraform.tfstate.enc
+            gpg --batch --passphrase ${{ inputs.passphrase }} -o .${{ inputs.statefile_location }}/terraform.tfstate -d ./state/terraform.tfstate.enc
           }
         }
       shell: pwsh
     - id: terraform-state-artifact-upload
       if: ${{ inputs.download_upload == 'upload' }}
       run: |
-        $ArtifactName = "${{ github.ref_name }}" + "${{ inputs.statefile_location }}"
-        $StateExists = Test-Path -Path ."${{ inputs.statefile_location }}"/terraform.tfstate -PathType Leaf
+        $ArtifactName = ${{ github.ref_name }} + ${{ inputs.statefile_location }}
+        $StateExists = Test-Path -Path .${{ inputs.statefile_location }}/terraform.tfstate -PathType Leaf
         if ($StateExists){
-          gpg --batch --symmetric --cipher-algo aes256 --digest-algo sha256 --passphrase "${{ inputs.passphrase }}" -o ."${{ inputs.statefile_location }}"/terraform.tfstate.enc ."${{ inputs.statefile_location }}"/terraform.tfstate
+          gpg --batch --symmetric --cipher-algo aes256 --digest-algo sha256 --passphrase ${{ inputs.passphrase }} -o .${{ inputs.statefile_location }}/terraform.tfstate.enc .${{ inputs.statefile_location }}/terraform.tfstate
         }
       shell: pwsh
     - uses: actions/upload-artifact@v3
       if: ${{ inputs.download_upload == 'upload' }}
       with:
         name: terraform-state
-        path: ."${{ inputs.statefile_location }}"/terraform.tfstate.enc
+        path: .${{ inputs.statefile_location }}/terraform.tfstate.enc
 branding:
   icon: 'cloud'
   color: 'gray-dark'

--- a/action.yml
+++ b/action.yml
@@ -1,25 +1,26 @@
-name: 'terraform_state_artifact'
+name: terraform-state-artifact
 description: 'Downloads and uploads your Terraform statefile as an encrypted Github Artifact'
-author: 'Sturla Bragason'
+author: 'Sturla Bragason & Gioele De Vitti'
+
 inputs:
-  encryptionkey:
+  encryption-key:
     description: 'Used as a key to encrypt and decrypt the statefile artifact'
     required: true
-  statefile_location:
-    description: 'Specify the location of your Terraform statefile.'
+  download-upload:
+    description: 'Whether to download and decrypt or upload and encrypt.'
+    required: true
+  statefile-location:
+    description: 'The location of your Terraform statefile.'
     required: false
     default: ''
-  download_upload:
-    description: 'Specify whether to download and decrypt or upload and encrypt.'
-    required: true
-    default: ''
+
 runs:
   using: "composite"
   steps:
-    - id: terraform_state_artifact_download
-      if: ${{ github.event.inputs.download_upload == 'download' }}
+    - id: terraform-state-artifact-download
+      if: ${{ github.event.inputs.download-upload == 'download' }}
       run: |
-        $ArtifactName = "${{ github.ref_name }}" + "${{ inputs.statefile_location }}"
+        $ArtifactName = "${{ github.ref_name }}" + "${{ inputs.statefile-location }}"
         $Repo = "${{ github.repository }}"
         $BaseUri = "https://api.github.com"
         $ArtifactUri = "$BaseUri/repos/$Repo/actions/artifacts"
@@ -31,23 +32,24 @@ runs:
           if ($MostRecentArtifactURI){
             Invoke-RestMethod -uri $MostRecentArtifactURI -Token $Token -Authentication bearer -outfile ./state.zip
             Expand-Archive ./state.zip
-            openssl enc -d -in ./state/terraform.tfstate.enc -aes-256-cbc -pbkdf2 -pass pass:"${{ inputs.encryptionkey }}" -out ."${{ inputs.statefile_location }}"/terraform.tfstate
+            openssl enc -d -in ./state/terraform.tfstate.enc -aes-256-cbc -pbkdf2 -pass pass:"${{ inputs.encryption-key }}" -out ."${{ inputs.statefile-location }}"/terraform.tfstate
           }
         }
       shell: pwsh
-    - id: terraform_state_artifact_upload
-      if: ${{ github.event.inputs.download_upload == 'upload' }}
+    - id: terraform-state-artifact-upload
+      if: ${{ github.event.inputs.download-upload == 'upload' }}
       run: |
-        $ArtifactName = "${{ github.ref_name }}" + "${{ inputs.statefile_location }}"
-        $StateExists = Test-Path -Path ."${{ inputs.statefile_location }}"/terraform.tfstate -PathType Leaf
+        $ArtifactName = "${{ github.ref_name }}" + "${{ inputs.statefile-location }}"
+        $StateExists = Test-Path -Path ."${{ inputs.statefile-location }}"/terraform.tfstate -PathType Leaf
         if ($StateExists){
-          openssl enc -in ."${{ inputs.statefile_location }}"/terraform.tfstate -aes-256-cbc -pbkdf2 -pass pass:"${{ inputs.encryptionkey }}" -out ."${{ inputs.statefile_location }}"/terraform.tfstate.enc
+          openssl enc -in ."${{ inputs.statefile-location }}"/terraform.tfstate -aes-256-cbc -pbkdf2 -pass pass:"${{ inputs.encryption-key }}" -out ."${{ inputs.statefile-location }}"/terraform.tfstate.enc
         }
       shell: pwsh
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
+      if: ${{ github.event.inputs.download-upload == 'upload' }}
       with:
-        name: terraformstatefile
-        path: ."${{ inputs.statefile_location }}"/terraform.tfstate.enc
+        name: terraform-state
+        path: ."${{ inputs.statefile-location }}"/terraform.tfstate.enc
 branding:
   icon: 'cloud'
   color: 'gray-dark'

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ runs:
   using: "composite"
   steps:
     - id: terraform-state-artifact-download
-      if: ${{ github.event.inputs.download_upload == 'download' }}
+      if: ${{ inputs.download_upload == 'download' }}
       run: |
         $ArtifactName = "${{ github.ref_name }}" + "${{ inputs.statefile_location }}"
         $Repo = "${{ github.repository }}"
@@ -37,7 +37,7 @@ runs:
         }
       shell: pwsh
     - id: terraform-state-artifact-upload
-      if: ${{ github.event.inputs.download_upload == 'upload' }}
+      if: ${{ inputs.download_upload == 'upload' }}
       run: |
         $ArtifactName = "${{ github.ref_name }}" + "${{ inputs.statefile_location }}"
         $StateExists = Test-Path -Path ."${{ inputs.statefile_location }}"/terraform.tfstate -PathType Leaf
@@ -46,7 +46,7 @@ runs:
         }
       shell: pwsh
     - uses: actions/upload-artifact@v3
-      if: ${{ github.event.inputs.download_upload == 'upload' }}
+      if: ${{ inputs.download_upload == 'upload' }}
       with:
         name: terraform-state
         path: ."${{ inputs.statefile_location }}"/terraform.tfstate.enc

--- a/action.yml
+++ b/action.yml
@@ -6,10 +6,10 @@ inputs:
   passphrase:
     description: 'A passphrase to encrypt and decrypt the statefile artifact.'
     required: true
-  download-upload:
+  download_upload:
     description: 'Whether to download and decrypt or upload and encrypt.'
     required: true
-  statefile-location:
+  statefile_location:
     description: 'The location of your Terraform statefile.'
     required: false
     default: ''
@@ -18,9 +18,9 @@ runs:
   using: "composite"
   steps:
     - id: terraform-state-artifact-download
-      if: ${{ github.event.inputs.download-upload == 'download' }}
+      if: ${{ github.event.inputs.download_upload == 'download' }}
       run: |
-        $ArtifactName = "${{ github.ref_name }}" + "${{ inputs.statefile-location }}"
+        $ArtifactName = "${{ github.ref_name }}" + "${{ inputs.statefile_location }}"
         $Repo = "${{ github.repository }}"
         $BaseUri = "https://api.github.com"
         $ArtifactUri = "$BaseUri/repos/$Repo/actions/artifacts"
@@ -32,24 +32,24 @@ runs:
           if ($MostRecentArtifactURI){
             Invoke-RestMethod -uri $MostRecentArtifactURI -Token $Token -Authentication bearer -outfile ./state.zip
             Expand-Archive ./state.zip
-            gpg --batch --passphrase "${{ inputs.passphrase }}" -o ."${{ inputs.statefile-location }}"/terraform.tfstate -d ./state/terraform.tfstate.enc
+            gpg --batch --passphrase "${{ inputs.passphrase }}" -o ."${{ inputs.statefile_location }}"/terraform.tfstate -d ./state/terraform.tfstate.enc
           }
         }
       shell: pwsh
     - id: terraform-state-artifact-upload
-      if: ${{ github.event.inputs.download-upload == 'upload' }}
+      if: ${{ github.event.inputs.download_upload == 'upload' }}
       run: |
-        $ArtifactName = "${{ github.ref_name }}" + "${{ inputs.statefile-location }}"
-        $StateExists = Test-Path -Path ."${{ inputs.statefile-location }}"/terraform.tfstate -PathType Leaf
+        $ArtifactName = "${{ github.ref_name }}" + "${{ inputs.statefile_location }}"
+        $StateExists = Test-Path -Path ."${{ inputs.statefile_location }}"/terraform.tfstate -PathType Leaf
         if ($StateExists){
-          gpg --batch --symmetric --cipher-algo aes256 --digest-algo sha256 --passphrase "${{ inputs.passphrase }}" -o ."${{ inputs.statefile-location }}"/terraform.tfstate.enc ."${{ inputs.statefile-location }}"/terraform.tfstate
+          gpg --batch --symmetric --cipher-algo aes256 --digest-algo sha256 --passphrase "${{ inputs.passphrase }}" -o ."${{ inputs.statefile_location }}"/terraform.tfstate.enc ."${{ inputs.statefile_location }}"/terraform.tfstate
         }
       shell: pwsh
     - uses: actions/upload-artifact@v3
-      if: ${{ github.event.inputs.download-upload == 'upload' }}
+      if: ${{ github.event.inputs.download_upload == 'upload' }}
       with:
         name: terraform-state
-        path: ."${{ inputs.statefile-location }}"/terraform.tfstate.enc
+        path: ."${{ inputs.statefile_location }}"/terraform.tfstate.enc
 branding:
   icon: 'cloud'
   color: 'gray-dark'

--- a/action.yml
+++ b/action.yml
@@ -1,63 +1,53 @@
 name: 'terraform_state_artifact'
-description: 'Sets up and runs Terraform, and creates an encrypted Terraform artifact'
+description: 'Downloads and uploads your Terraform statefile as an encrypted Github Artifact'
 author: 'Sturla Bragason'
 inputs:
   encryptionkey:
-    description: 'Used to read artifact and as a key to encrypt and decrypt the state file artifact'
+    description: 'Used as a key to encrypt and decrypt the statefile artifact'
     required: true
-  apply:
-    description: 'terraform apply'
-    required: false
-    default: true
-  custom_plan_flags:
-    description: 'Add custom flags to the terraform plan command'
+  statefile_location:
+    description: 'Specify the location of your Terraform statefile.'
     required: false
     default: ''
-  custom_apply_flags:
-    description: 'Add custom flags to the terraform apply command'
-    required: false
+  download_upload:
+    description: 'Specify whether to download and decrypt or upload and encrypt.'
+    required: true
     default: ''
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v2
-    - uses: hashicorp/setup-terraform@v1
-    - id: terraform
+    - id: terraform_state_artifact_download
+      if: ${{ github.event.inputs.download_upload == 'download' }}
       run: |
+        $ArtifactName = "${{ github.ref_name }}" + "${{ inputs.statefile_location }}"
         $Repo = "${{ github.repository }}"
         $BaseUri = "https://api.github.com"
         $ArtifactUri = "$BaseUri/repos/$Repo/actions/artifacts"
         $Token = "${{ github.token }}" | ConvertTo-SecureString -AsPlainText
         $RestResponse = Invoke-RestMethod -Authentication Bearer -Uri $ArtifactUri -Token $Token | Select-Object -ExpandProperty artifacts
         if ($RestResponse){
-          $MostRecentArtifactURI = $RestResponse | Sort-Object -Property created_at -Descending | where name -eq "terraformstatefile" | Select-Object -First 1 | Select-Object -ExpandProperty archive_download_url
+          $MostRecentArtifactURI = $RestResponse | Sort-Object -Property created_at -Descending | where name -eq $ArtifactName | Select-Object -First 1 | Select-Object -ExpandProperty archive_download_url
           Write-Host "Most recent artifact URI = $MostRecentArtifactURI"
           if ($MostRecentArtifactURI){
             Invoke-RestMethod -uri $MostRecentArtifactURI -Token $Token -Authentication bearer -outfile ./state.zip
             Expand-Archive ./state.zip
-            openssl enc -d -in ./state/terraform.tfstate.enc -aes-256-cbc -pbkdf2 -pass pass:"${{ inputs.encryptionkey }}" -out ./terraform.tfstate
+            openssl enc -d -in ./state/terraform.tfstate.enc -aes-256-cbc -pbkdf2 -pass pass:"${{ inputs.encryptionkey }}" -out ."${{ inputs.statefile_location }}"/terraform.tfstate
           }
         }
-        terraform init
-        $terraformapply = "${{ inputs.apply }}"
-        $custom_plan_flags = "${{ inputs.custom_plan_flags }}"
-        $custom_apply_flags = "${{ inputs.custom_apply_flags }}"
-        if ($terraformapply -eq "false"){
-          $terraformapply = $false
-        }
-        terraform plan $custom_plan_flags
-        if ($terraformapply){
-          terraform apply -auto-approve $custom_apply_flags
-        }
-        $StateExists = Test-Path -Path ./terraform.tfstate -PathType Leaf
+      shell: pwsh
+    - id: terraform_state_artifact_upload
+      if: ${{ github.event.inputs.download_upload == 'upload' }}
+      run: |
+        $ArtifactName = "${{ github.ref_name }}" + "${{ inputs.statefile_location }}"
+        $StateExists = Test-Path -Path ."${{ inputs.statefile_location }}"/terraform.tfstate -PathType Leaf
         if ($StateExists){
-          openssl enc -in ./terraform.tfstate -aes-256-cbc -pbkdf2 -pass pass:"${{ inputs.encryptionkey }}" -out ./terraform.tfstate.enc
+          openssl enc -in ."${{ inputs.statefile_location }}"/terraform.tfstate -aes-256-cbc -pbkdf2 -pass pass:"${{ inputs.encryptionkey }}" -out ."${{ inputs.statefile_location }}"/terraform.tfstate.enc
         }
       shell: pwsh
     - uses: actions/upload-artifact@v2
       with:
         name: terraformstatefile
-        path: ./terraform.tfstate.enc
+        path: ."${{ inputs.statefile_location }}"/terraform.tfstate.enc
 branding:
   icon: 'cloud'
   color: 'gray-dark'

--- a/action.yml
+++ b/action.yml
@@ -3,8 +3,8 @@ description: 'Downloads and uploads your Terraform statefile as an encrypted Git
 author: 'Sturla Bragason & Gioele De Vitti'
 
 inputs:
-  encryption-key:
-    description: 'Used as a key to encrypt and decrypt the statefile artifact'
+  passphrase:
+    description: 'A passphrase to encrypt and decrypt the statefile artifact.'
     required: true
   download-upload:
     description: 'Whether to download and decrypt or upload and encrypt.'
@@ -32,7 +32,7 @@ runs:
           if ($MostRecentArtifactURI){
             Invoke-RestMethod -uri $MostRecentArtifactURI -Token $Token -Authentication bearer -outfile ./state.zip
             Expand-Archive ./state.zip
-            openssl enc -d -in ./state/terraform.tfstate.enc -aes-256-cbc -pbkdf2 -pass pass:"${{ inputs.encryption-key }}" -out ."${{ inputs.statefile-location }}"/terraform.tfstate
+            gpg --batch --passphrase "${{ inputs.passphrase }}" -o ."${{ inputs.statefile-location }}"/terraform.tfstate -d ./state/terraform.tfstate.enc
           }
         }
       shell: pwsh
@@ -42,7 +42,7 @@ runs:
         $ArtifactName = "${{ github.ref_name }}" + "${{ inputs.statefile-location }}"
         $StateExists = Test-Path -Path ."${{ inputs.statefile-location }}"/terraform.tfstate -PathType Leaf
         if ($StateExists){
-          openssl enc -in ."${{ inputs.statefile-location }}"/terraform.tfstate -aes-256-cbc -pbkdf2 -pass pass:"${{ inputs.encryption-key }}" -out ."${{ inputs.statefile-location }}"/terraform.tfstate.enc
+          gpg --batch --symmetric --cipher-algo aes256 --digest-algo sha256 --passphrase "${{ inputs.passphrase }}" -o ."${{ inputs.statefile-location }}"/terraform.tfstate.enc ."${{ inputs.statefile-location }}"/terraform.tfstate
         }
       shell: pwsh
     - uses: actions/upload-artifact@v3

--- a/action.yml
+++ b/action.yml
@@ -20,14 +20,13 @@ runs:
     - id: terraform-state-artifact-download
       if: ${{ inputs.download_upload == 'download' }}
       run: |
-        $ArtifactName = "${{ github.ref_name }}" + "${{ inputs.statefile_location }}"
         $Repo = "${{ github.repository }}"
         $BaseUri = "https://api.github.com"
         $ArtifactUri = "$BaseUri/repos/$Repo/actions/artifacts"
         $Token = "${{ github.token }}" | ConvertTo-SecureString -AsPlainText
         $RestResponse = Invoke-RestMethod -Authentication Bearer -Uri $ArtifactUri -Token $Token | Select-Object -ExpandProperty artifacts
         if ($RestResponse){
-          $MostRecentArtifactURI = $RestResponse | Sort-Object -Property created_at -Descending | where name -eq $ArtifactName | Select-Object -First 1 | Select-Object -ExpandProperty archive_download_url
+          $MostRecentArtifactURI = $RestResponse | Sort-Object -Property created_at -Descending | where name -eq "terraform-state" | Select-Object -First 1 | Select-Object -ExpandProperty archive_download_url
           Write-Host "Most recent artifact URI = $MostRecentArtifactURI"
           if ($MostRecentArtifactURI){
             Invoke-RestMethod -uri $MostRecentArtifactURI -Token $Token -Authentication bearer -outfile ./state.zip
@@ -39,7 +38,6 @@ runs:
     - id: terraform-state-artifact-upload
       if: ${{ inputs.download_upload == 'upload' }}
       run: |
-        $ArtifactName = "${{ github.ref_name }}" + "${{ inputs.statefile_location }}"
         $StateExists = Test-Path -Path .${{ inputs.statefile_location }}/terraform.tfstate -PathType Leaf
         if ($StateExists){
           gpg --batch --symmetric --cipher-algo aes256 --digest-algo sha256 --passphrase ${{ inputs.passphrase }} -o .${{ inputs.statefile_location }}/terraform.tfstate.enc .${{ inputs.statefile_location }}/terraform.tfstate

--- a/main.tf
+++ b/main.tf
@@ -6,12 +6,14 @@ terraform {
     }
   }
 }
+
 resource "random_id" "random" {
   keepers = {
    random_id = "${var.run_id}"
   }
   byte_length = 8
 }
+
 variable "run_id" {
   type = string
 }


### PR DESCRIPTION
- Use GPG instead of OpenSSL without IV
- Let users decide when to download or upload the state, like already suggested at [V2 of this repo](https://github.com/sturlabragason/terraform_state_artifact/blob/v2/action.yml)
- Update integration testing to fit changes